### PR TITLE
Phase 5: rules engine logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ dist-ssr/
 *.local
 .vite/
 
+# Internal working docs
+docs/policy-engine-numeric-values.md
+
 # Logs
 *.log
 npm-debug.log*

--- a/docs/design-spec-v1.md
+++ b/docs/design-spec-v1.md
@@ -1,5 +1,5 @@
 # Token Policy
-## Spec v10
+## Spec v1
 
 ---
 

--- a/src/engine/index.test.ts
+++ b/src/engine/index.test.ts
@@ -401,6 +401,15 @@ describe('idleTimeout numeric values', () => {
   })
 })
 
+// ── idleTimeoutIdp mirrors idleTimeoutApp ─────────────────────────────────
+
+describe('idleTimeoutIdp mirrors idleTimeoutApp', () => {
+  it('idleTimeoutIdp.value equals idleTimeoutApp.value', () => {
+    const r = computePolicy({ ...base, sensitivityTier: 'medium', complianceFramework: 'hipaa' })
+    expect(r.idleTimeoutIdp?.value).toBe(r.idleTimeoutApp?.value)
+  })
+})
+
 // ── compliance-driven standardsFloor — idle timeout ──────────────────────
 
 describe('idleTimeout standardsFloor — compliance driven', () => {
@@ -465,6 +474,12 @@ describe('accessTokenLifetime upgradeNote', () => {
 
   it('no upgradeNote when binding is already configured', () => {
     const r = computePolicy({ ...base, sensitivityTier: 'medium', tokenBinding: 'dpop' })
+    expect(r.accessTokenLifetime.upgradeNote).toBeUndefined()
+  })
+
+  it('no upgradeNote for non-M2M low sensitivity with no binding', () => {
+    // Low sensitivity non-M2M: threshold not met, no upgrade note expected
+    const r = computePolicy({ ...base, appType: 'server', sensitivityTier: 'low', tokenBinding: 'none' })
     expect(r.accessTokenLifetime.upgradeNote).toBeUndefined()
   })
 })

--- a/src/engine/index.test.ts
+++ b/src/engine/index.test.ts
@@ -156,25 +156,26 @@ describe('warning: high-sliding-no-absolute', () => {
   })
 })
 
-// ── no-revocation — moved to disclaimer ───────────────────────────────────
+// ── revocation advisory — now in warnings, not disclaimer ─────────────────
 
-describe('revocation advisory in disclaimer', () => {
-  it('no-revocation is not in warnings', () => {
+describe('revocation advisory', () => {
+  it('no-revocation id is not in warnings (old id retired)', () => {
     expect(warningIds(base)).not.toContain('no-revocation')
     expect(warningIds({ ...base, appType: 'm2m' })).not.toContain('no-revocation')
   })
 
-  it('disclaimer always contains RFC 7009 revocation advisory', () => {
-    expect(computePolicy(base).disclaimer.some((d) => d.includes('RFC 7009'))).toBe(true)
+  it('token-revocation advisory is in warnings, not disclaimer', () => {
+    expect(computePolicy(base).warnings.some((w) => w.id === 'token-revocation')).toBe(true)
+    expect(computePolicy(base).disclaimer.some((d) => d.includes('RFC 7009'))).toBe(false)
   })
 
   it('disclaimer always contains the base boilerplate', () => {
     expect(computePolicy(base).disclaimer.some((d) => d.includes('NIST SP 800-63B Rev 4'))).toBe(true)
   })
 
-  it('disclaimer applies to M2M as well', () => {
+  it('token-revocation advisory applies to M2M as well', () => {
     expect(
-      computePolicy({ ...base, appType: 'm2m' }).disclaimer.some((d) => d.includes('RFC 7009'))
+      computePolicy({ ...base, appType: 'm2m' }).warnings.some((w) => w.id === 'token-revocation')
     ).toBe(true)
   })
 })
@@ -216,6 +217,18 @@ describe('refresh token output', () => {
     const result = computePolicy({ ...base, appType: 'server', refreshTokenUsage: 'yes' })
     expect(result.refreshTokenRotation.value).toBe('recommended')
   })
+
+  it('refreshTokenRotation rationale names DPoP when dpop binding is configured', () => {
+    const result = computePolicy({ ...base, appType: 'spa', refreshTokenUsage: 'yes', tokenBinding: 'dpop' })
+    expect(result.refreshTokenRotation.rationale).toContain('DPoP')
+    expect(result.refreshTokenRotation.rationale).not.toContain('mTLS')
+  })
+
+  it('refreshTokenRotation rationale names mTLS when mtls binding is configured', () => {
+    const result = computePolicy({ ...base, appType: 'spa', refreshTokenUsage: 'yes', tokenBinding: 'mtls' })
+    expect(result.refreshTokenRotation.rationale).toContain('mTLS')
+    expect(result.refreshTokenRotation.rationale).not.toContain('DPoP')
+  })
 })
 
 // ── tokenStorage citations ────────────────────────────────────────────────
@@ -243,6 +256,310 @@ describe('tokenStorage citations', () => {
     const citation = storeCitation({ ...base, appType: 'm2m' })
     expect(citation?.standard).toBe('RFC 6749')
     expect(citation?.clause).toBe('§4.4')
+  })
+})
+
+// ── access token lifetime ─────────────────────────────────────────────────
+
+describe('accessTokenLifetime numeric values', () => {
+  it('server + low + none → 60', () => {
+    expect(computePolicy({ ...base }).accessTokenLifetime.value).toBe(60)
+  })
+
+  it('server + low + fedramp-high → 15', () => {
+    expect(
+      computePolicy({ ...base, complianceFramework: 'fedramp-high' }).accessTokenLifetime.value
+    ).toBe(15)
+  })
+
+  it('spa + high + none → 15', () => {
+    expect(
+      computePolicy({ ...base, appType: 'spa', sensitivityTier: 'high' }).accessTokenLifetime.value
+    ).toBe(15)
+  })
+
+  it('spa + low + none → 30, rationale names SPA public client baseline', () => {
+    const result = computePolicy({ ...base, appType: 'spa' })
+    expect(result.accessTokenLifetime.value).toBe(30)
+    expect(result.accessTokenLifetime.rationale).toContain('SPA public client baseline')
+  })
+
+  it('spa + medium + fedramp-moderate → 30, three-way tie, compliance post-check names FedRAMP Moderate', () => {
+    // base=30, sensitivityCap=30, complianceCap=30 — all tie at 30
+    // bindingMin strict < keeps base first; post-check: complianceCap=30=value → compliance named
+    const result = computePolicy({
+      ...base,
+      appType: 'spa',
+      sensitivityTier: 'medium',
+      complianceFramework: 'fedramp-moderate',
+    })
+    expect(result.accessTokenLifetime.value).toBe(30)
+    expect(result.accessTokenLifetime.rationale).toContain('FedRAMP Moderate')
+  })
+
+  it('server + low + none → 60, tie between base and sensitivity, rationale names Server confidential client baseline', () => {
+    // base=60, sensitivityCap=60 — tie; strict < keeps first = base
+    const result = computePolicy({ ...base })
+    expect(result.accessTokenLifetime.value).toBe(60)
+    expect(result.accessTokenLifetime.rationale).toContain('Server confidential client baseline')
+  })
+})
+
+// ── refresh token lifetime ────────────────────────────────────────────────
+
+describe('refreshTokenLifetime numeric values', () => {
+  it('mobile + low + none + employees → 20160 (14d base)', () => {
+    expect(
+      computePolicy({
+        ...base,
+        appType: 'mobile',
+        sensitivityTier: 'low',
+        complianceFramework: 'none',
+        userPopulation: 'employees',
+        refreshTokenUsage: 'yes',
+      }).refreshTokenLifetime?.value
+    ).toBe(20160)
+  })
+
+  it('mobile + low + none + partners → 1440 (partner cap)', () => {
+    expect(
+      computePolicy({
+        ...base,
+        appType: 'mobile',
+        sensitivityTier: 'low',
+        complianceFramework: 'none',
+        userPopulation: 'partners',
+        refreshTokenUsage: 'yes',
+      }).refreshTokenLifetime?.value
+    ).toBe(1440)
+  })
+
+  it('server + high + hipaa → 480 (high sensitivity cap)', () => {
+    expect(
+      computePolicy({
+        ...base,
+        appType: 'server',
+        sensitivityTier: 'high',
+        complianceFramework: 'hipaa',
+        refreshTokenUsage: 'yes',
+      }).refreshTokenLifetime?.value
+    ).toBe(480)
+  })
+
+  it('server + low + none + consumers → 10080 (server base, consumer cap=43200 does not bind)', () => {
+    expect(
+      computePolicy({
+        ...base,
+        appType: 'server',
+        sensitivityTier: 'low',
+        complianceFramework: 'none',
+        userPopulation: 'consumers',
+        refreshTokenUsage: 'yes',
+      }).refreshTokenLifetime?.value
+    ).toBe(10080)
+  })
+})
+
+// ── absolute session limit ────────────────────────────────────────────────
+
+describe('absoluteSessionLimit numeric values', () => {
+  it('medium + fedramp-moderate → 720 (compliance cap = sensitivity default, picks compliance)', () => {
+    expect(
+      computePolicy({ ...base, sensitivityTier: 'medium', complianceFramework: 'fedramp-moderate' })
+        .absoluteSessionLimit?.value
+    ).toBe(720)
+  })
+
+  it('high + none → 480', () => {
+    expect(
+      computePolicy({ ...base, sensitivityTier: 'high' }).absoluteSessionLimit?.value
+    ).toBe(480)
+  })
+
+  it('low + hipaa → 480 (hipaa cap overrides 1440 default)', () => {
+    expect(
+      computePolicy({ ...base, sensitivityTier: 'low', complianceFramework: 'hipaa' })
+        .absoluteSessionLimit?.value
+    ).toBe(480)
+  })
+})
+
+// ── idle timeout ──────────────────────────────────────────────────────────
+
+describe('idleTimeout numeric values', () => {
+  it('medium + none → 30', () => {
+    expect(
+      computePolicy({ ...base, sensitivityTier: 'medium' }).idleTimeoutApp?.value
+    ).toBe(30)
+  })
+
+  it('low + hipaa → 15 (hipaa cap overrides 60 default)', () => {
+    expect(
+      computePolicy({ ...base, sensitivityTier: 'low', complianceFramework: 'hipaa' })
+        .idleTimeoutApp?.value
+    ).toBe(15)
+  })
+})
+
+// ── compliance-driven standardsFloor — idle timeout ──────────────────────
+
+describe('idleTimeout standardsFloor — compliance driven', () => {
+  it('low + hipaa: floor cites HIPAA, not AAL1 optional', () => {
+    const r = computePolicy({ ...base, complianceFramework: 'hipaa' })
+    expect(r.idleTimeoutApp!.standardsFloor).toContain('HIPAA')
+    expect(r.idleTimeoutApp!.standardsFloor).not.toContain('optional')
+  })
+
+  it('low + fedramp-moderate: floor cites SC-10, not AAL1 optional', () => {
+    const r = computePolicy({ ...base, complianceFramework: 'fedramp-moderate' })
+    expect(r.idleTimeoutApp!.standardsFloor).toContain('SC-10')
+    expect(r.idleTimeoutApp!.standardsFloor).not.toContain('optional')
+  })
+
+  it('medium + fedramp-moderate (tie): compliance named, floor cites SC-10', () => {
+    const r = computePolicy({ ...base, sensitivityTier: 'medium', complianceFramework: 'fedramp-moderate' })
+    expect(r.idleTimeoutApp!.rationale).toContain('FedRAMP Moderate')
+    expect(r.idleTimeoutApp!.standardsFloor).toContain('SC-10')
+  })
+})
+
+// ── compliance-driven standardsFloor — absolute session ───────────────────
+
+describe('absoluteSessionLimit standardsFloor — compliance driven', () => {
+  it('medium + hipaa: floor cites HIPAA, not "stricter at 12h"', () => {
+    const r = computePolicy({ ...base, sensitivityTier: 'medium', complianceFramework: 'hipaa' })
+    expect(r.absoluteSessionLimit!.standardsFloor).toContain('HIPAA')
+    expect(r.absoluteSessionLimit!.standardsFloor).not.toContain('12h')
+  })
+
+  it('low + fedramp-high: floor cites AAL3', () => {
+    const r = computePolicy({ ...base, complianceFramework: 'fedramp-high' })
+    expect(r.absoluteSessionLimit!.standardsFloor).toContain('AAL3')
+  })
+
+  it('medium + fedramp-moderate (tie): compliance named, floor cites AAL2', () => {
+    const r = computePolicy({ ...base, sensitivityTier: 'medium', complianceFramework: 'fedramp-moderate' })
+    expect(r.absoluteSessionLimit!.rationale).toContain('FedRAMP Moderate')
+    expect(r.absoluteSessionLimit!.standardsFloor).toContain('AAL2')
+  })
+})
+
+// ── AT upgradeNote — DPoP vs mTLS by app type ─────────────────────────────
+
+describe('accessTokenLifetime upgradeNote', () => {
+  it('M2M + no binding: suggests mTLS, not DPoP', () => {
+    const r = computePolicy({ ...base, appType: 'm2m', sensitivityTier: 'medium' })
+    expect(r.accessTokenLifetime.upgradeNote).toContain('mTLS')
+    expect(r.accessTokenLifetime.upgradeNote).not.toContain('DPoP')
+  })
+
+  it('M2M + low sensitivity + no binding: still suggests mTLS', () => {
+    const r = computePolicy({ ...base, appType: 'm2m' })
+    expect(r.accessTokenLifetime.upgradeNote).toContain('mTLS')
+  })
+
+  it('server + medium + no binding: suggests DPoP', () => {
+    const r = computePolicy({ ...base, sensitivityTier: 'medium' })
+    expect(r.accessTokenLifetime.upgradeNote).toContain('DPoP')
+  })
+
+  it('no upgradeNote when binding is already configured', () => {
+    const r = computePolicy({ ...base, sensitivityTier: 'medium', tokenBinding: 'dpop' })
+    expect(r.accessTokenLifetime.upgradeNote).toBeUndefined()
+  })
+})
+
+// ── token-revocation advisory ─────────────────────────────────────────────
+
+describe('token-revocation advisory', () => {
+  it('present in warnings for standard inputs', () => {
+    expect(computePolicy(base).warnings.some((w) => w.id === 'token-revocation')).toBe(true)
+  })
+
+  it('kind is advisory', () => {
+    const w = computePolicy(base).warnings.find((w) => w.id === 'token-revocation')
+    expect(w?.kind).toBe('advisory')
+  })
+
+  it('present for M2M as well', () => {
+    expect(
+      computePolicy({ ...base, appType: 'm2m' }).warnings.some((w) => w.id === 'token-revocation')
+    ).toBe(true)
+  })
+})
+
+// ── deferred warnings do not fire for standard inputs ─────────────────────
+
+describe('deferred computed warnings', () => {
+  it('consumer-rt-30d does not fire for standard inputs', () => {
+    expect(
+      computePolicy({
+        ...base,
+        userPopulation: 'consumers',
+        refreshTokenUsage: 'yes',
+      }).warnings.map((w) => w.id)
+    ).not.toContain('consumer-rt-30d')
+  })
+
+  it('idle-exceeds-absolute does not fire for standard inputs', () => {
+    expect(warningIds(base)).not.toContain('idle-exceeds-absolute')
+  })
+})
+
+// ── refresh=no suppression ────────────────────────────────────────────────
+
+describe('refresh=no suppression', () => {
+  it('rtLifetime is null', () => {
+    expect(computePolicy({ ...base, refreshTokenUsage: 'no' }).refreshTokenLifetime).toBeNull()
+  })
+
+  it('rotation value is not-applicable', () => {
+    expect(computePolicy({ ...base, refreshTokenUsage: 'no' }).refreshTokenRotation.value).toBe(
+      'not-applicable'
+    )
+  })
+
+  it('rotation rationale is "Refresh tokens not in use."', () => {
+    expect(computePolicy({ ...base, refreshTokenUsage: 'no' }).refreshTokenRotation.rationale).toBe(
+      'Refresh tokens not in use.'
+    )
+  })
+})
+
+// ── no-TODO checks ────────────────────────────────────────────────────────
+
+describe('no TODO strings in output', () => {
+  it('rotation rationale has no TODO', () => {
+    expect(
+      computePolicy({ ...base, refreshTokenUsage: 'yes' }).refreshTokenRotation.rationale
+    ).not.toContain('TODO')
+  })
+
+  it('token storage recommendation has no TODO', () => {
+    expect(computePolicy(base).tokenStorage.recommendation).not.toContain('TODO')
+  })
+
+  it('rotation rationale when refresh=no has no TODO', () => {
+    expect(
+      computePolicy({ ...base, refreshTokenUsage: 'no' }).refreshTokenRotation.rationale
+    ).not.toContain('TODO')
+  })
+
+  it('access token lifetime rationale has no TODO', () => {
+    expect(computePolicy(base).accessTokenLifetime.rationale).not.toContain('TODO')
+  })
+})
+
+// ── conditional warning kind ──────────────────────────────────────────────
+
+describe('conditional warning kind', () => {
+  it('spa-fedramp-high has kind conditional', () => {
+    const w = computePolicy({
+      ...base,
+      appType: 'spa',
+      complianceFramework: 'fedramp-high',
+    }).warnings.find((w) => w.id === 'spa-fedramp-high')
+    expect(w?.kind).toBe('conditional')
   })
 })
 

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -62,7 +62,7 @@ function bindingMin(candidates: Array<[number, string]>): [number, string] {
 
 // ── Binding constraint label map ────────────────────────────────────────────
 
-const AT_BASE_LABEL: Record<AppType, string> = {
+const APP_TYPE_BASE_LABEL: Record<AppType, string> = {
   spa: 'SPA public client baseline',
   server: 'Server confidential client baseline',
   mobile: 'Mobile public client baseline',
@@ -94,7 +94,7 @@ function computeAccessTokenLifetime(inputs: PolicyInputs): NumericRecommendation
   const complianceFramework = inputs.complianceFramework ?? 'none'
 
   const candidates: Array<[number, string]> = [
-    [AT_BASE[appType], AT_BASE_LABEL[appType]],
+    [AT_BASE[appType], APP_TYPE_BASE_LABEL[appType]],
     [AT_SENSITIVITY_CAP[sensitivityTier], SENSITIVITY_LABEL[sensitivityTier]],
   ]
   const complianceCap = AT_COMPLIANCE_CAP[complianceFramework]
@@ -140,7 +140,7 @@ function computeRefreshTokenLifetime(inputs: PolicyInputs): NumericRecommendatio
   const userPopulation = inputs.userPopulation ?? 'employees'
 
   const candidates: Array<[number, string]> = [
-    [RT_BASE[appType], AT_BASE_LABEL[appType]],
+    [RT_BASE[appType], APP_TYPE_BASE_LABEL[appType]],
   ]
   const populationCap = RT_POPULATION_CAP[userPopulation]
   if (populationCap !== undefined) {
@@ -194,10 +194,8 @@ function computeAbsoluteSessionLimit(inputs: PolicyInputs): NumericRecommendatio
   }
 
   const [value, rawLabel] = bindingMin(candidates)
-  const label =
-    complianceCap !== undefined && complianceCap === value
-      ? COMPLIANCE_LABEL[complianceFramework]!
-      : rawLabel
+  const isComplianceBinding = complianceCap !== undefined && complianceCap === value
+  const label = isComplianceBinding ? COMPLIANCE_LABEL[complianceFramework]! : rawLabel
 
   const sensitivityFloorMap: Record<SensitivityTier, string> = {
     low: 'Community practice. NIST SP 800-63B Rev 4 AAL1: session limit SHALL be established; SHOULD ≤30 days.',
@@ -205,14 +203,17 @@ function computeAbsoluteSessionLimit(inputs: PolicyInputs): NumericRecommendatio
       'NIST SP 800-63B Rev 4 AAL2: SHALL establish; SHOULD ≤24h. Recommendation is stricter at 12h — aligned with Rev 3 AAL2 SHALL.',
     high: 'Community practice — stricter than AAL2 24h SHOULD, aligned with AAL3 12h SHALL as a conservative target.',
   }
-  const complianceFloorMap: Record<string, string> = {
-    'HIPAA community practice':
+  // Keyed on ComplianceFramework to avoid silent breakage if COMPLIANCE_LABEL strings change.
+  const complianceFloorMap: Partial<Record<ComplianceFramework, string>> = {
+    hipaa:
       'Community practice for ePHI access environments. HIPAA §164.312(a)(2)(iii) requires automatic logoff — no specific numeric value mandated.',
-    'FedRAMP Moderate compliance controls':
+    'fedramp-moderate':
       'NIST SP 800-63B Rev 4 AAL2: SHALL establish; SHOULD ≤24h. Recommendation is stricter at 12h — aligned with Rev 3 AAL2 SHALL.',
-    'FedRAMP High compliance controls': 'NIST SP 800-63B Rev 4 AAL3: SHALL ≤12h.',
+    'fedramp-high': 'NIST SP 800-63B Rev 4 AAL3: SHALL ≤12h.',
   }
-  const standardsFloor = complianceFloorMap[label] ?? sensitivityFloorMap[sensitivityTier]
+  const standardsFloor =
+    (isComplianceBinding ? complianceFloorMap[complianceFramework] : undefined) ??
+    sensitivityFloorMap[sensitivityTier]
 
   return {
     value,
@@ -236,10 +237,8 @@ function computeIdleTimeout(inputs: PolicyInputs): NumericRecommendation | null 
   }
 
   const [value, rawLabel] = bindingMin(candidates)
-  const label =
-    complianceCap !== undefined && complianceCap === value
-      ? COMPLIANCE_LABEL[complianceFramework]!
-      : rawLabel
+  const isComplianceBinding = complianceCap !== undefined && complianceCap === value
+  const label = isComplianceBinding ? COMPLIANCE_LABEL[complianceFramework]! : rawLabel
 
   const sensitivityFloorMap: Record<SensitivityTier, string> = {
     low: 'Community practice. NIST SP 800-63B Rev 4 AAL1: inactivity timeout is optional (MAY).',
@@ -247,19 +246,22 @@ function computeIdleTimeout(inputs: PolicyInputs): NumericRecommendation | null 
       'NIST SP 800-63B Rev 4 AAL2: inactivity timeout SHOULD ≤60 min. Recommendation is stricter at 30 min — aligned with Rev 3 AAL2 SHALL 30 min.',
     high: 'NIST SP 800-63B Rev 4 AAL3: inactivity timeout SHOULD ≤15 min.',
   }
-  const complianceFloorMap: Record<string, string> = {
-    'HIPAA community practice':
+  // Keyed on ComplianceFramework to avoid silent breakage if COMPLIANCE_LABEL strings change.
+  const complianceFloorMap: Partial<Record<ComplianceFramework, string>> = {
+    hipaa:
       'Community practice. HIPAA §164.312(a)(2)(iii) automatic logoff is addressable — no specific numeric value mandated. 15 min is industry standard for clinical environments.',
-    'FedRAMP Moderate compliance controls':
+    'fedramp-moderate':
       'NIST SP 800-63B Rev 4 AAL2: inactivity timeout SHOULD ≤60 min. SC-10 mandates inactivity disconnect — 30 min aligned with NIST Rev 3 AAL2 SHALL 30 min.',
-    'FedRAMP High compliance controls':
+    'fedramp-high':
       'NIST SP 800-63B Rev 4 AAL3: inactivity timeout SHOULD ≤15 min. SC-10 FedRAMP High: 15 min for user sessions.',
   }
 
   return {
     value,
     rationale: `${label} drives this value.`,
-    standardsFloor: complianceFloorMap[label] ?? sensitivityFloorMap[sensitivityTier],
+    standardsFloor:
+      (isComplianceBinding ? complianceFloorMap[complianceFramework] : undefined) ??
+      sensitivityFloorMap[sensitivityTier],
   }
 }
 

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -1,11 +1,269 @@
 import type {
+  AppType,
+  UserPopulation,
+  SensitivityTier,
+  ComplianceFramework,
   PolicyInputs,
   PolicyResult,
   PolicyWarning,
   PolicyCitation,
+  NumericRecommendation,
 } from './types'
 
-// ── Warning detection ──────────────────────────────────────────────────────
+// ── Lookup tables ───────────────────────────────────────────────────────────
+
+const AT_BASE: Record<AppType, number> = { spa: 30, server: 60, mobile: 30, m2m: 60 }
+const AT_SENSITIVITY_CAP: Record<SensitivityTier, number> = { low: 60, medium: 30, high: 15 }
+const AT_COMPLIANCE_CAP: Partial<Record<ComplianceFramework, number>> = {
+  'fedramp-moderate': 30,
+  'fedramp-high': 15,
+}
+
+const RT_BASE: Record<AppType, number> = { spa: 1440, server: 10080, mobile: 20160, m2m: 0 }
+const RT_SENSITIVITY_CAP: Record<SensitivityTier, number> = { low: 43200, medium: 10080, high: 480 }
+const RT_COMPLIANCE_CAP: Partial<Record<ComplianceFramework, number>> = {
+  hipaa: 720,
+  'fedramp-moderate': 1440,
+  'fedramp-high': 720,
+}
+const RT_POPULATION_CAP: Partial<Record<UserPopulation, number>> = {
+  consumers: 43200,
+  partners: 1440,
+}
+
+const ABS_SESSION_SENSITIVITY: Record<SensitivityTier, number> = { low: 1440, medium: 720, high: 480 }
+const ABS_SESSION_COMPLIANCE: Partial<Record<ComplianceFramework, number>> = {
+  hipaa: 480,
+  'fedramp-moderate': 720,
+  'fedramp-high': 720,
+}
+
+const IDLE_SENSITIVITY: Record<SensitivityTier, number> = { low: 60, medium: 30, high: 15 }
+const IDLE_COMPLIANCE: Partial<Record<ComplianceFramework, number>> = {
+  hipaa: 15,
+  'fedramp-moderate': 30,
+  'fedramp-high': 15,
+}
+
+// ── bindingMin helper ───────────────────────────────────────────────────────
+
+// Returns [value, bindingLabel] for the minimum candidate.
+// When tied, the FIRST candidate in the array wins — callers must order candidates
+// from least to most specific: [base, population, sensitivity, compliance].
+// Ties resolve to the less specific constraint, which is the more intuitive label
+// (e.g. server+low+none shows "Server confidential client baseline", not "Low sensitivity").
+function bindingMin(candidates: Array<[number, string]>): [number, string] {
+  let result = candidates[0]
+  for (const c of candidates) {
+    if (c[0] < result[0]) result = c
+  }
+  return result
+}
+
+// ── Binding constraint label map ────────────────────────────────────────────
+
+const AT_BASE_LABEL: Record<AppType, string> = {
+  spa: 'SPA public client baseline',
+  server: 'Server confidential client baseline',
+  mobile: 'Mobile public client baseline',
+  m2m: 'M2M confidential client baseline',
+}
+
+const SENSITIVITY_LABEL: Record<SensitivityTier, string> = {
+  low: 'Low sensitivity',
+  medium: 'Medium sensitivity',
+  high: 'High sensitivity',
+}
+
+const COMPLIANCE_LABEL: Partial<Record<ComplianceFramework, string>> = {
+  hipaa: 'HIPAA community practice',
+  'fedramp-moderate': 'FedRAMP Moderate compliance controls',
+  'fedramp-high': 'FedRAMP High compliance controls',
+}
+
+const POPULATION_LABEL: Partial<Record<UserPopulation, string>> = {
+  consumers: 'Consumer population boundary',
+  partners: 'Partner population boundary',
+}
+
+// ── Numeric field computations ──────────────────────────────────────────────
+
+function computeAccessTokenLifetime(inputs: PolicyInputs): NumericRecommendation {
+  const appType = inputs.appType ?? 'server'
+  const sensitivityTier = inputs.sensitivityTier ?? 'low'
+  const complianceFramework = inputs.complianceFramework ?? 'none'
+
+  const candidates: Array<[number, string]> = [
+    [AT_BASE[appType], AT_BASE_LABEL[appType]],
+    [AT_SENSITIVITY_CAP[sensitivityTier], SENSITIVITY_LABEL[sensitivityTier]],
+  ]
+  const complianceCap = AT_COMPLIANCE_CAP[complianceFramework]
+  if (complianceCap !== undefined) {
+    candidates.push([complianceCap, COMPLIANCE_LABEL[complianceFramework]!])
+  }
+
+  const [value, rawLabel] = bindingMin(candidates)
+  // Post-check: if compliance is active and its cap matches the result, name compliance.
+  // Preserves < tie-breaking for cases with no active compliance (e.g. server+low+none)
+  // while ensuring a selected compliance framework is named when it determines the value.
+  const label =
+    complianceCap !== undefined && complianceCap === value
+      ? COMPLIANCE_LABEL[complianceFramework]!
+      : rawLabel
+
+  let upgradeNote: string | undefined
+  if (inputs.tokenBinding === 'none') {
+    if (appType === 'm2m') {
+      upgradeNote = 'mTLS (RFC 8705) would bind tokens to the client certificate for this M2M flow.'
+    } else if (sensitivityTier !== 'low') {
+      upgradeNote =
+        'Consider DPoP sender-constraining (RFC 9449) to reduce post-theft exposure without shortening token lifetime.'
+    }
+  }
+
+  return {
+    value,
+    rationale: `${label} drives this value.`,
+    standardsFloor:
+      'No specific value mandated. RFC 9700 §4.14.2 recommends short-lived access tokens combined with refresh tokens.',
+    upgradeNote,
+  }
+}
+
+function computeRefreshTokenLifetime(inputs: PolicyInputs): NumericRecommendation | null {
+  const isM2M = inputs.appType === 'm2m'
+  if (isM2M || inputs.refreshTokenUsage !== 'yes') return null
+
+  const appType = inputs.appType ?? 'server'
+  const sensitivityTier = inputs.sensitivityTier ?? 'low'
+  const complianceFramework = inputs.complianceFramework ?? 'none'
+  const userPopulation = inputs.userPopulation ?? 'employees'
+
+  const candidates: Array<[number, string]> = [
+    [RT_BASE[appType], AT_BASE_LABEL[appType]],
+  ]
+  const populationCap = RT_POPULATION_CAP[userPopulation]
+  if (populationCap !== undefined) {
+    candidates.push([populationCap, POPULATION_LABEL[userPopulation]!])
+  }
+  candidates.push([RT_SENSITIVITY_CAP[sensitivityTier], SENSITIVITY_LABEL[sensitivityTier]])
+  const complianceCap = RT_COMPLIANCE_CAP[complianceFramework]
+  if (complianceCap !== undefined) {
+    candidates.push([complianceCap, COMPLIANCE_LABEL[complianceFramework]!])
+  }
+
+  const [value, rawLabel] = bindingMin(candidates)
+  const label =
+    complianceCap !== undefined && complianceCap === value
+      ? COMPLIANCE_LABEL[complianceFramework]!
+      : rawLabel
+
+  // upgradeNote fires on population='partners' regardless of whether the population cap
+  // was the binding constraint. For SPA+partners, RT_BASE['spa']=1440 ties with
+  // RT_POPULATION_CAP['partners']=1440 — the partner cap adds no restriction over the base,
+  // but the note is still contextually correct: external trust boundary is the reason the
+  // value is acceptable at 24h, not just a coincidence of the SPA base. No population
+  // post-check equivalent to the compliance post-check is applied here because the cap not
+  // binding below the base means it genuinely isn't the constraining factor.
+  const upgradeNote =
+    userPopulation === 'partners'
+      ? 'Partner population boundary drives daily re-authentication. External trust boundaries warrant shorter persistent access windows than internal employees.'
+      : undefined
+
+  return {
+    value,
+    rationale: `${label} drives this value.`,
+    standardsFloor:
+      'No specific value mandated. RFC 6749 §10.4 recommends limiting refresh token lifetime.',
+    upgradeNote,
+  }
+}
+
+function computeAbsoluteSessionLimit(inputs: PolicyInputs): NumericRecommendation | null {
+  if (inputs.appType === 'm2m') return null
+
+  const sensitivityTier = inputs.sensitivityTier ?? 'low'
+  const complianceFramework = inputs.complianceFramework ?? 'none'
+
+  const candidates: Array<[number, string]> = [
+    [ABS_SESSION_SENSITIVITY[sensitivityTier], SENSITIVITY_LABEL[sensitivityTier]],
+  ]
+  const complianceCap = ABS_SESSION_COMPLIANCE[complianceFramework]
+  if (complianceCap !== undefined) {
+    candidates.push([complianceCap, COMPLIANCE_LABEL[complianceFramework]!])
+  }
+
+  const [value, rawLabel] = bindingMin(candidates)
+  const label =
+    complianceCap !== undefined && complianceCap === value
+      ? COMPLIANCE_LABEL[complianceFramework]!
+      : rawLabel
+
+  const sensitivityFloorMap: Record<SensitivityTier, string> = {
+    low: 'Community practice. NIST SP 800-63B Rev 4 AAL1: session limit SHALL be established; SHOULD ≤30 days.',
+    medium:
+      'NIST SP 800-63B Rev 4 AAL2: SHALL establish; SHOULD ≤24h. Recommendation is stricter at 12h — aligned with Rev 3 AAL2 SHALL.',
+    high: 'Community practice — stricter than AAL2 24h SHOULD, aligned with AAL3 12h SHALL as a conservative target.',
+  }
+  const complianceFloorMap: Record<string, string> = {
+    'HIPAA community practice':
+      'Community practice for ePHI access environments. HIPAA §164.312(a)(2)(iii) requires automatic logoff — no specific numeric value mandated.',
+    'FedRAMP Moderate compliance controls':
+      'NIST SP 800-63B Rev 4 AAL2: SHALL establish; SHOULD ≤24h. Recommendation is stricter at 12h — aligned with Rev 3 AAL2 SHALL.',
+    'FedRAMP High compliance controls': 'NIST SP 800-63B Rev 4 AAL3: SHALL ≤12h.',
+  }
+  const standardsFloor = complianceFloorMap[label] ?? sensitivityFloorMap[sensitivityTier]
+
+  return {
+    value,
+    rationale: `${label} drives this value.`,
+    standardsFloor,
+  }
+}
+
+function computeIdleTimeout(inputs: PolicyInputs): NumericRecommendation | null {
+  if (inputs.appType === 'm2m') return null
+
+  const sensitivityTier = inputs.sensitivityTier ?? 'low'
+  const complianceFramework = inputs.complianceFramework ?? 'none'
+
+  const candidates: Array<[number, string]> = [
+    [IDLE_SENSITIVITY[sensitivityTier], SENSITIVITY_LABEL[sensitivityTier]],
+  ]
+  const complianceCap = IDLE_COMPLIANCE[complianceFramework]
+  if (complianceCap !== undefined) {
+    candidates.push([complianceCap, COMPLIANCE_LABEL[complianceFramework]!])
+  }
+
+  const [value, rawLabel] = bindingMin(candidates)
+  const label =
+    complianceCap !== undefined && complianceCap === value
+      ? COMPLIANCE_LABEL[complianceFramework]!
+      : rawLabel
+
+  const sensitivityFloorMap: Record<SensitivityTier, string> = {
+    low: 'Community practice. NIST SP 800-63B Rev 4 AAL1: inactivity timeout is optional (MAY).',
+    medium:
+      'NIST SP 800-63B Rev 4 AAL2: inactivity timeout SHOULD ≤60 min. Recommendation is stricter at 30 min — aligned with Rev 3 AAL2 SHALL 30 min.',
+    high: 'NIST SP 800-63B Rev 4 AAL3: inactivity timeout SHOULD ≤15 min.',
+  }
+  const complianceFloorMap: Record<string, string> = {
+    'HIPAA community practice':
+      'Community practice. HIPAA §164.312(a)(2)(iii) automatic logoff is addressable — no specific numeric value mandated. 15 min is industry standard for clinical environments.',
+    'FedRAMP Moderate compliance controls':
+      'NIST SP 800-63B Rev 4 AAL2: inactivity timeout SHOULD ≤60 min. SC-10 mandates inactivity disconnect — 30 min aligned with NIST Rev 3 AAL2 SHALL 30 min.',
+    'FedRAMP High compliance controls':
+      'NIST SP 800-63B Rev 4 AAL3: inactivity timeout SHOULD ≤15 min. SC-10 FedRAMP High: 15 min for user sessions.',
+  }
+
+  return {
+    value,
+    rationale: `${label} drives this value.`,
+    standardsFloor: complianceFloorMap[label] ?? sensitivityFloorMap[sensitivityTier],
+  }
+}
+
+// ── Warning detection ───────────────────────────────────────────────────────
 
 function detectWarnings(inputs: PolicyInputs): PolicyWarning[] {
   const warnings: PolicyWarning[] = []
@@ -23,6 +281,7 @@ function detectWarnings(inputs: PolicyInputs): PolicyWarning[] {
   if (appType === 'spa' && complianceFramework === 'fedramp-high') {
     warnings.push({
       id: 'spa-fedramp-high',
+      kind: 'conditional',
       message:
         'FedRAMP High controls SC-10, SC-23, and AC-12 require server-enforced session management, server-side session identifier generation, and demonstrable session termination. Client-side token deletion is insufficient — the token remains valid server-side. Adopt a Backend for Frontend (BFF) pattern. FedRAMP-authorized SPA products (Okta, Salesforce) all use server-side session backends.',
     })
@@ -33,6 +292,7 @@ function detectWarnings(inputs: PolicyInputs): PolicyWarning[] {
   if (appType === 'spa' && refreshTokenUsage === 'yes') {
     warnings.push({
       id: 'spa-refresh-no-bff',
+      kind: 'conditional',
       message:
         'Refresh tokens in browser-accessible storage are vulnerable to XSS exfiltration. Rotation alone is insufficient — a persistent attacker can steal rotated tokens continuously before the application uses them. Primary mitigation: BFF pattern (tokens never reach the browser). If BFF is not feasible: DPoP sender-constraining plus strict CSP.',
     })
@@ -42,6 +302,7 @@ function detectWarnings(inputs: PolicyInputs): PolicyWarning[] {
   if (appType === 'spa' && sensitivityTier === 'high' && tokenBinding === 'none') {
     warnings.push({
       id: 'spa-high-no-binding',
+      kind: 'conditional',
       message:
         'No sender-constraining configured. A stolen bearer token is valid for the full access token lifetime with no way to invalidate it mid-flight. Short access token lifetime and refresh token rotation reduce the window — they do not eliminate the risk. BFF pattern recommended as primary mitigation.',
     })
@@ -52,6 +313,7 @@ function detectWarnings(inputs: PolicyInputs): PolicyWarning[] {
   if (appType === 'mobile' && idleBehavior === 'sliding') {
     warnings.push({
       id: 'mobile-sliding-window',
+      kind: 'conditional',
       message:
         'iOS aggressively suspends background processes, which can interrupt token refresh and cause unexpected session termination. Validate token refresh behavior against OWASP MASTG and platform-specific guidance before relying on sliding window behavior.',
     })
@@ -62,6 +324,7 @@ function detectWarnings(inputs: PolicyInputs): PolicyWarning[] {
   if (appType === 'm2m' && complianceFramework === 'hipaa') {
     warnings.push({
       id: 'm2m-hipaa',
+      kind: 'conditional',
       message:
         'HIPAA §164.312(a)(1) covers software programs granted access rights to ePHI — including M2M. BAA requirements under 45 CFR §§164.502(e) and 164.504(e) apply regardless of whether access is human or automated. This tool covers technical token controls only.',
     })
@@ -73,21 +336,59 @@ function detectWarnings(inputs: PolicyInputs): PolicyWarning[] {
   if (sensitivityTier === 'high' && idleBehavior === 'sliding') {
     warnings.push({
       id: 'high-sliding-no-absolute',
+      kind: 'conditional',
       message:
         'Idle timeout alone is insufficient at high sensitivity. An attacker with a hijacked session can generate periodic activity to prevent the idle timeout from firing indefinitely. NIST 800-63B Rev 4 mandates an absolute session limit at AAL2 (SHALL) and recommends an inactivity timeout (SHOULD) — both should be applied. Add an absolute session limit.',
     })
   }
 
-  // TODO(phase-5): consumer + refresh token lifetime > 30 days
-  // Requires computed refreshTokenLifetime.value — add after numeric values are filled in.
+  return warnings
+}
 
-  // TODO(phase-5): idle timeout > absolute session limit
-  // Requires computed idleTimeoutApp.value and absoluteSessionLimit.value.
+function detectComputedWarnings(
+  inputs: PolicyInputs,
+  computed: { rtLifetime: number | null; idleTimeout: number | null; absoluteSession: number | null }
+): PolicyWarning[] {
+  const warnings: PolicyWarning[] = []
+
+  // Defensive guard: currently unreachable — consumer cap (43200) equals the low sensitivity
+  // cap and no RT base exceeds 20160, so rtLifetime can never exceed 43200 with present
+  // values. Kept to protect against future table adjustments that could push the computed
+  // value past 30 days without anyone noticing.
+  if (
+    inputs.userPopulation === 'consumers' &&
+    computed.rtLifetime !== null &&
+    computed.rtLifetime > 43200
+  ) {
+    warnings.push({
+      id: 'consumer-rt-30d',
+      kind: 'conditional',
+      message:
+        'Refresh token lifetime exceeds 30 days for a consumer population. Shared and lost devices increase the risk of unauthorized access. Consider capping refresh token lifetime at 30 days for consumer-facing applications.',
+    })
+  }
+
+  // Guards against misconfigured sessions. Currently unreachable — for every valid
+  // sensitivity+compliance combination, idle timeout is strictly less than the absolute
+  // session limit (verified programmatically). Kept as a safety net against future table
+  // changes or inputs that produce unexpected combinations.
+  if (
+    computed.idleTimeout !== null &&
+    computed.absoluteSession !== null &&
+    computed.idleTimeout > computed.absoluteSession
+  ) {
+    warnings.push({
+      id: 'idle-exceeds-absolute',
+      kind: 'conditional',
+      message:
+        'Idle timeout is longer than the absolute session limit. The absolute session limit will fire before the idle timeout — the idle timeout is effectively unreachable. Reduce the idle timeout to be shorter than the absolute session limit.',
+    })
+  }
 
   return warnings
 }
 
-// ── Citations assembly ─────────────────────────────────────────────────────
+// ── Citations assembly ──────────────────────────────────────────────────────
 
 function assembleCitations(inputs: PolicyInputs): PolicyCitation[] {
   const citations: PolicyCitation[] = []
@@ -95,32 +396,31 @@ function assembleCitations(inputs: PolicyInputs): PolicyCitation[] {
   const usesRefreshTokens = inputs.refreshTokenUsage === 'yes' && !isM2M
 
   // Access token lifetime — always cited
-  // NOTE: RFC 9700 §2.2.1 covers sender-constraining, not lifetime. The correct
-  // sub-section for short-lived access token guidance must be confirmed in phase-5.
   citations.push({
     field: 'accessTokenLifetime',
     standard: 'RFC 9700',
-    note: 'TODO(phase-5): identify correct clause for short-lived access token requirement and connect to recommendation.',
+    clause: '§4.14.2',
+    note: 'Short-lived access tokens combined with refresh tokens. No specific numeric value mandated — recommendation reflects community practice by app type, sensitivity, and compliance framework.',
   })
   citations.push({
     field: 'accessTokenLifetime',
     standard: 'RFC 9068',
-    note: 'TODO(phase-5): connect JWT access token lifetime to profile guidance.',
+    note: 'JWT access token profile. Access token lifetime is set by the authorization server; this tool recommends values consistent with the short-lived access token pattern.',
   })
 
   // Refresh token lifetime and rotation
   if (usesRefreshTokens) {
     citations.push({
       field: 'refreshTokenLifetime',
-      standard: 'RFC 9700',
-      clause: '§2.2.2',
-      note: 'TODO(phase-5): connect refresh token lifetime to rotation and binding requirements.',
+      standard: 'RFC 6749',
+      clause: '§10.4',
+      note: 'Refresh token lifetime should be limited. Recommendation reflects minimum of app-type base, sensitivity cap, compliance cap, and user population cap.',
     })
     citations.push({
       field: 'refreshTokenRotation',
       standard: 'RFC 9700',
       clause: '§2.2.2',
-      note: 'TODO(phase-5): public clients MUST use rotation OR sender-constraining (RFC 9700 §2.2.2). Confidential clients: rotation is an additional protection; §2.2.2 does not mandate it.',
+      note: 'Public clients MUST use refresh token rotation OR sender-constraining. Confidential clients: rotation is additional protection; §2.2.2 does not mandate it.',
     })
   }
 
@@ -129,17 +429,17 @@ function assembleCitations(inputs: PolicyInputs): PolicyCitation[] {
     citations.push({
       field: 'absoluteSessionLimit',
       standard: 'NIST SP 800-63B Rev 4',
-      note: 'TODO(phase-5): cite AAL2+ absolute session limit clause.',
+      note: 'AAL2: absolute session limit SHALL be established; SHOULD ≤24h. AAL3: SHALL ≤12h. Recommendation may be stricter — aligned with Rev 3 SHALL values where Rev 4 relaxed to SHOULD.',
     })
     citations.push({
       field: 'idleTimeoutIdp',
       standard: 'NIST SP 800-63B Rev 4',
-      note: 'TODO(phase-5): cite inactivity timeout clause and IdP/app-layer alignment requirement.',
+      note: 'IdP inactivity timeout must mirror the application-layer value. NIST SP 800-63B Rev 3 §7.2.1: CSP and RP govern sessions independently in federated scenarios.',
     })
     citations.push({
       field: 'idleTimeoutApp',
       standard: 'NIST SP 800-63B Rev 4',
-      note: 'TODO(phase-5): cite app-layer idle detection requirement.',
+      note: 'AAL2: inactivity timeout SHOULD ≤60 min. AAL3: SHOULD ≤15 min. Application layer must enforce independently from the IdP.',
     })
   }
 
@@ -148,26 +448,29 @@ function assembleCitations(inputs: PolicyInputs): PolicyCitation[] {
     citations.push({
       field: 'tokenStorage',
       standard: 'draft-ietf-oauth-browser-based-apps-26',
-      note: 'TODO(phase-5): cite BFF as primary token storage pattern for browser-based apps.',
+      clause: '§6.1',
+      note: 'BFF pattern is the recommended token storage architecture for browser-based apps — tokens never reach the browser. httpOnly cookies are the fallback when BFF is not feasible.',
     })
   } else if (inputs.appType === 'server') {
     citations.push({
       field: 'tokenStorage',
       standard: 'RFC 6749',
-      note: 'TODO(phase-5): confidential client — tokens held server-side, never exposed to the browser.',
+      clause: '§10.3',
+      note: 'Confidential client — tokens held server-side, never exposed to the browser.',
     })
   } else if (inputs.appType === 'mobile') {
     citations.push({
       field: 'tokenStorage',
       standard: 'RFC 8252',
-      note: 'TODO(phase-5): cite secure storage requirements for native apps per OAuth 2.0 for Native Apps; cross-reference OWASP MASTG.',
+      clause: '§8.12',
+      note: 'Native apps must use platform secure storage. Cross-reference OWASP MASTG for iOS Keychain and Android Keystore implementation guidance.',
     })
   } else if (inputs.appType === 'm2m') {
     citations.push({
       field: 'tokenStorage',
       standard: 'RFC 6749',
       clause: '§4.4',
-      note: 'TODO(phase-5): client credentials — secrets stored server-side, never in code or client-accessible config.',
+      note: 'Client credentials — secrets stored server-side in a secrets manager or restricted environment variable store. Never in source code or client-accessible config.',
     })
   }
 
@@ -177,14 +480,14 @@ function assembleCitations(inputs: PolicyInputs): PolicyCitation[] {
       field: 'tokenBinding',
       standard: 'RFC 9449',
       clause: '§11.2',
-      note: 'TODO(phase-5): DPoP binding rationale; note nonce requirement for lifetime extension.',
+      note: 'DPoP sender-constrains tokens to the client key pair. Without server-issued nonces, DPoP SHOULD NOT be used to extend token lifetime — binding reduces post-theft utility, not the lifetime recommendation.',
     })
   }
   if (inputs.tokenBinding === 'mtls') {
     citations.push({
       field: 'tokenBinding',
       standard: 'RFC 8705',
-      note: 'TODO(phase-5): mTLS binding rationale; standards are silent on lifetime extension.',
+      note: 'mTLS certificate-bound tokens. Standards are silent on lifetime extension for mTLS-bound tokens — binding reduces post-theft utility but does not change the lifetime recommendation.',
     })
   }
 
@@ -203,104 +506,155 @@ function assembleCitations(inputs: PolicyInputs): PolicyCitation[] {
   return citations
 }
 
-// ── Re-auth triggers ───────────────────────────────────────────────────────
+// ── Re-auth triggers ────────────────────────────────────────────────────────
 
-function buildReAuthTriggers(inputs: PolicyInputs): {
-  idp: string[]
-  app: string[]
-} {
+function buildReAuthTriggers(
+  inputs: PolicyInputs,
+  absoluteSessionLimit: number | null,
+  idleTimeout: number | null
+): { idp: string[]; app: string[] } {
   if (inputs.appType === 'm2m') {
     return { idp: [], app: [] }
   }
 
   return {
     idp: [
-      'TODO(phase-5): absolute session limit (max age) — hard cap on total session length',
-      'TODO(phase-5): inactivity timeout — must mirror the app-layer idle timeout value',
+      `Set max_age to ${absoluteSessionLimit} minutes to enforce the absolute session limit at the IdP.`,
+      `Set inactivity timeout to ${idleTimeout} minutes — must match the application-layer idle timeout.`,
     ],
     app: [
-      'TODO(phase-5): idle detection and session termination after N minutes of inactivity',
-      'Step-up re-authentication before sensitive actions — accessing PHI, changing credentials, payment transactions',
-      'Re-authentication on privilege escalation',
+      `Redirect to login after ${idleTimeout} minutes of inactivity.`,
+      'Step-up re-authentication before sensitive actions — accessing PHI, changing credentials, payment transactions.',
+      'Re-authentication on privilege escalation.',
     ],
   }
 }
 
-// ── Disclaimer assembly ────────────────────────────────────────────────────
+// ── Disclaimer assembly ─────────────────────────────────────────────────────
 
 const BASE_DISCLAIMER =
   'Recommendations are grounded in NIST SP 800-63B Rev 4, RFC 9700, RFC 6749, RFC 9068, and draft-ietf-oauth-browser-based-apps-26 — not a compliance determination or substitute for a security review. Verify against your ATO, organizational requirements, or legal counsel. Standards basis last verified: March 2026.'
 
-// Token revocation advisory — applies to all app types but is not a targeted
-// warning since this tool cannot verify AS revocation support. Surfaced as a
-// disclaimer note rather than a warning to avoid false-positive fatigue.
-const REVOCATION_ADVISORY =
-  'This tool cannot verify whether your authorization server supports RFC 7009 token revocation. Revocation is required for NIST 800-63B §7.1 logout compliance (user-session apps) and recommended for all deployments. Verify support before relying on token expiry as the sole invalidation mechanism.'
-
 function buildDisclaimer(): string[] {
-  return [BASE_DISCLAIMER, REVOCATION_ADVISORY]
+  return [BASE_DISCLAIMER]
 }
 
-// ── computePolicy ──────────────────────────────────────────────────────────
-
-// Placeholder used for all numeric fields until phase-5 values are designed.
-const TODO = 'TODO(phase-5): value to be filled in during rules engine logic phase'
+// ── computePolicy ───────────────────────────────────────────────────────────
 
 export function computePolicy(inputs: PolicyInputs): PolicyResult {
   const isM2M = inputs.appType === 'm2m'
   const usesRefreshTokens = inputs.refreshTokenUsage === 'yes' && !isM2M
 
-  const warnings = detectWarnings(inputs)
+  const accessTokenLifetime = computeAccessTokenLifetime(inputs)
+  const refreshTokenLifetime = computeRefreshTokenLifetime(inputs)
+  const absoluteSessionLimit = computeAbsoluteSessionLimit(inputs)
+  const idleTimeout = computeIdleTimeout(inputs)
+
+  // ── Refresh token rotation ──────────────────────────────────────────────
+  let refreshTokenRotation: PolicyResult['refreshTokenRotation']
+
+  if (!usesRefreshTokens) {
+    refreshTokenRotation = {
+      value: 'not-applicable',
+      rationale: 'Refresh tokens not in use.',
+      standardsFloor: '',
+    }
+  } else if (inputs.appType === 'spa' || inputs.appType === 'mobile') {
+    const binding = inputs.tokenBinding
+    const bindingRationale =
+      binding === 'dpop'
+        ? 'DPoP sender-constraining satisfies RFC 9700 §2.2.2. Rotation adds defense-in-depth.'
+        : binding === 'mtls'
+        ? 'mTLS sender-constraining satisfies RFC 9700 §2.2.2. Rotation adds defense-in-depth.'
+        : null
+    refreshTokenRotation = {
+      value: bindingRationale ? 'recommended' : 'required',
+      rationale:
+        bindingRationale ?? 'No sender-constraining configured — rotation satisfies the public client requirement.',
+      standardsFloor:
+        'RFC 9700 §2.2.2: refresh tokens for public clients MUST be sender-constrained or use rotation.',
+    }
+  } else {
+    // Confidential client (server)
+    const sensitivityTier = inputs.sensitivityTier ?? 'low'
+    const complianceFramework = inputs.complianceFramework ?? 'none'
+    const isHighAssurance =
+      sensitivityTier === 'high' ||
+      complianceFramework === 'hipaa' ||
+      complianceFramework === 'fedramp-moderate' ||
+      complianceFramework === 'fedramp-high'
+    refreshTokenRotation = {
+      value: 'recommended',
+      rationale: isHighAssurance
+        ? 'Defense-in-depth at high assurance. Community practice in regulated environments.'
+        : 'Additional protection — not required by RFC 9700 §2.2.2 for confidential clients.',
+      standardsFloor: 'RFC 9700 §2.2.2 does not require rotation for confidential clients.',
+    }
+  }
+
+  // ── Token storage ───────────────────────────────────────────────────────
+  const appType = inputs.appType ?? 'server'
+  const tokenStorageMap: Record<AppType, PolicyResult['tokenStorage']> = {
+    spa: {
+      recommendation:
+        'BFF pattern (Backend for Frontend) — tokens are held server-side and never reach the browser.',
+      rationale:
+        'Browser-accessible storage (localStorage, sessionStorage) is vulnerable to XSS. The BFF pattern eliminates token exposure to the browser entirely. draft-ietf-oauth-browser-based-apps-26 §6.1.',
+      upgradeNote:
+        'If BFF is not feasible: httpOnly cookies with Secure and SameSite=Strict attributes. localStorage and sessionStorage are not acceptable for medium or high sensitivity.',
+    },
+    server: {
+      recommendation: 'Server-side session store. Tokens never sent to the client browser.',
+      rationale: 'Confidential client — tokens held server-side per RFC 6749 §10.3.',
+    },
+    mobile: {
+      recommendation: 'Platform secure storage — iOS Keychain Services, Android Keystore.',
+      rationale:
+        'Native secure storage isolates tokens from other apps and prevents extraction. RFC 8252 §8.12; OWASP MASTG for platform-specific guidance.',
+    },
+    m2m: {
+      recommendation:
+        'Server-side secret store (vault, secrets manager, or environment variables with restricted access). Never in source code or client-accessible config.',
+      rationale: 'Community practice for client credentials management.',
+      upgradeNote:
+        'Prefer a dedicated secrets manager (HashiCorp Vault, AWS Secrets Manager) over environment variables for rotation and audit trail support.',
+    },
+  }
+
+  const computed = {
+    rtLifetime: refreshTokenLifetime?.value ?? null,
+    idleTimeout: idleTimeout?.value ?? null,
+    absoluteSession: absoluteSessionLimit?.value ?? null,
+  }
+
+  const conditionalWarnings = [
+    ...detectWarnings(inputs),
+    ...detectComputedWarnings(inputs, computed),
+  ]
+
+  const advisories: PolicyWarning[] = [
+    {
+      id: 'token-revocation',
+      kind: 'advisory',
+      message:
+        'Verify your authorization server supports and enforces RFC 7009 token revocation. Without revocation, compromised tokens remain valid until expiry.',
+    },
+  ]
+
+  const reAuth = buildReAuthTriggers(inputs, computed.absoluteSession, computed.idleTimeout)
   const citations = assembleCitations(inputs)
-  const reAuth = buildReAuthTriggers(inputs)
 
   return {
-    accessTokenLifetime: {
-      value: 0, // TODO(phase-5)
-      rationale: TODO,
-      standardsFloor: TODO,
-    },
-
-    // RFC 6749 §4.4.3 permits but does not require refresh tokens for the client
-    // credentials grant. Not issued for M2M — the client re-authenticates directly.
-    refreshTokenLifetime: usesRefreshTokens
-      ? { value: 0, rationale: TODO, standardsFloor: TODO } // TODO(phase-5)
-      : null,
-
-    refreshTokenRotation: {
-      // TODO(phase-5): refine per RFC 9700 §2.2.2 — public clients (SPA, mobile) MUST
-      // use rotation OR sender-constraining. Confidential clients (server): rotation
-      // is an additional protection; §2.2.2 does not mandate it.
-      // Stub uses 'required' for public clients, 'recommended' for confidential.
-      value: isM2M || !usesRefreshTokens
-        ? 'not-applicable'
-        : inputs.appType === 'server'
-        ? 'recommended'
-        : 'required',
-      rationale: TODO,
-      standardsFloor: TODO,
-    },
-
-    absoluteSessionLimit: isM2M
-      ? null
-      : { value: 0, rationale: TODO, standardsFloor: TODO }, // TODO(phase-5)
-
-    idleTimeoutIdp: isM2M
-      ? null
-      : { value: 0, rationale: TODO, standardsFloor: TODO }, // TODO(phase-5)
-
-    idleTimeoutApp: isM2M
-      ? null
-      : { value: 0, rationale: TODO, standardsFloor: TODO }, // TODO(phase-5)
-
-    tokenStorage: {
-      recommendation: TODO, // TODO(phase-5)
-      rationale: TODO,
-    },
-
+    accessTokenLifetime,
+    refreshTokenLifetime,
+    refreshTokenRotation,
+    absoluteSessionLimit,
+    idleTimeoutIdp: idleTimeout,
+    idleTimeoutApp: idleTimeout,
+    tokenStorage: tokenStorageMap[appType],
     reAuthTriggersIdp: reAuth.idp,
     reAuthTriggersApp: reAuth.app,
-    warnings,
+    warnings: [...conditionalWarnings, ...advisories],
     citations,
     disclaimer: buildDisclaimer(),
   }

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -46,6 +46,7 @@ export type RefreshTokenRotation = 'required' | 'recommended' | 'not-applicable'
 export interface PolicyWarning {
   id: string
   message: string
+  kind: 'conditional' | 'advisory'
 }
 
 export interface PolicyCitation {


### PR DESCRIPTION
## Summary

- Implements all numeric recommendations in the rules engine — access token lifetime, refresh token lifetime, absolute session limit, and idle timeout — grounded in the values table in the internal spec
- Fills in refresh token rotation rationale, token storage recommendations, re-auth trigger copy, warning `kind` field, citation notes, and the universal `token-revocation` advisory
- Removes all `TODO` placeholder strings and the `TODO` constant
- Adds 80 Vitest tests covering binding constraint selection, compliance/sensitivity/population caps, three-way tie annotation, mTLS vs DPoP rotation rationale, advisory kind, deferred warning guards, and refresh=no suppression

Closes #5. Also resolves the open question tracked in #11 (bindingMin tie-breaking — first/least-specific candidate wins; compliance post-check overrides when the compliance cap matches the selected value). Issue #13 (phase 6 UI wiring) remains open per v1 decision.

## Test plan

- [x] `npx vitest run` — all 80 tests pass
- [x] No `TODO` strings remain in `src/engine/`
- [x] Spot-check: server+low+none AT = 60 min, rationale names "SPA public client baseline" / "Server confidential client baseline" as appropriate
- [x] Spot-check: HIPAA idle timeout = 15 min, standardsFloor cites HIPAA not AAL1 optional (MAY)
- [x] Spot-check: advisory `token-revocation` present and `kind === 'advisory'` for all input combinations including M2M