### PR TITLE
Phase 6: result card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ docs/policy-engine-numeric-values.md
 *.log
 npm-debug.log*
 yarn-debug.log*
+
+# playwright-mcp
+.playwright-mcp/

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useStepFlow } from '@/hooks/useStepFlow'
 import { STEP_CONFIGS } from '@/data/stepConfigs'
@@ -29,6 +30,11 @@ function App() {
     reset,
   } = useStepFlow()
 
+  const result = useMemo(
+    () => (isComplete ? computePolicy(inputs as PolicyInputs) : null),
+    [inputs, isComplete]
+  )
+
   const currentValue = inputs[currentStep.id]
   const showNext = currentValue !== undefined
 
@@ -48,9 +54,9 @@ function App() {
       </header>
 
       <main className="mx-auto max-w-4xl px-5 py-8 sm:px-8 sm:py-10">
-        {isComplete ? (
+        {isComplete && result ? (
           <ResultCard
-            result={computePolicy(inputs as Required<PolicyInputs>)}
+            result={result}
             inputs={inputs}
             onReset={reset}
           />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,9 @@ import { STEP_CONFIGS } from '@/data/stepConfigs'
 import { StepperSidebar } from '@/components/StepperSidebar'
 import { StepQuestion } from '@/components/StepQuestion'
 import { StepNavigator } from '@/components/StepNavigator'
+import { ResultCard } from '@/components/ResultCard'
+import { computePolicy } from '@/engine'
+import type { PolicyInputs } from '@/engine/types'
 
 const variants = {
   enter: (dir: number) => ({ x: dir > 0 ? 80 : -80, opacity: 0 }),
@@ -23,6 +26,7 @@ function App() {
     goToStep,
     isComplete,
     canGoBack,
+    reset,
   } = useStepFlow()
 
   const currentValue = inputs[currentStep.id]
@@ -45,14 +49,11 @@ function App() {
 
       <main className="mx-auto max-w-4xl px-5 py-8 sm:px-8 sm:py-10">
         {isComplete ? (
-          <div className="rounded-xl border border-border bg-card p-10 text-center shadow-sm">
-            <p className="text-xl font-semibold tracking-display">
-              Assessment complete
-            </p>
-            <p className="mt-3 text-sm text-muted-foreground">
-              Policy recommendation will appear here.
-            </p>
-          </div>
+          <ResultCard
+            result={computePolicy(inputs as Required<PolicyInputs>)}
+            inputs={inputs}
+            onReset={reset}
+          />
         ) : (
           <div className="rounded-xl border border-border bg-card shadow-sm">
             {/* Mobile: step indicator above content */}

--- a/src/components/CitationsPanel.tsx
+++ b/src/components/CitationsPanel.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react'
+import { ChevronDown, ChevronUp } from 'lucide-react'
+import type { PolicyCitation } from '@/engine/types'
+
+interface CitationsPanelProps {
+  citations: PolicyCitation[]
+}
+
+const FIELD_LABELS: Record<string, string> = {
+  accessTokenLifetime: 'Access token lifetime',
+  refreshTokenLifetime: 'Refresh token lifetime',
+  refreshTokenRotation: 'Refresh token rotation',
+  absoluteSessionLimit: 'Absolute session limit',
+  idleTimeoutIdp: 'Idle timeout — IdP',
+  idleTimeoutApp: 'Idle timeout — application',
+  tokenStorage: 'Token storage',
+  tokenBinding: 'Token binding',
+  complianceNote: 'Compliance note',
+}
+
+export function CitationsPanel({ citations }: CitationsPanelProps) {
+  const [openFields, setOpenFields] = useState<Set<string>>(new Set())
+
+  // Group by field, preserving insertion order
+  const groups = citations.reduce<Map<string, PolicyCitation[]>>((acc, c) => {
+    const existing = acc.get(c.field)
+    if (existing) {
+      existing.push(c)
+    } else {
+      acc.set(c.field, [c])
+    }
+    return acc
+  }, new Map())
+
+  const toggle = (field: string) => {
+    setOpenFields((prev) => {
+      const next = new Set(prev)
+      if (next.has(field)) {
+        next.delete(field)
+      } else {
+        next.add(field)
+      }
+      return next
+    })
+  }
+
+  return (
+    <div className="flex flex-col divide-y divide-border">
+      {Array.from(groups.entries()).map(([field, items]) => {
+        const isOpen = openFields.has(field)
+        const label = FIELD_LABELS[field] ?? field
+        return (
+          <div key={field} className="py-2">
+            <button
+              type="button"
+              onClick={() => toggle(field)}
+              className="flex w-full items-center justify-between gap-2 py-1 text-left"
+            >
+              <span className="text-[11px] uppercase tracking-label text-muted-foreground">
+                {label}
+              </span>
+              {isOpen ? (
+                <ChevronUp size={12} className="shrink-0 text-muted-foreground" />
+              ) : (
+                <ChevronDown size={12} className="shrink-0 text-muted-foreground" />
+              )}
+            </button>
+            {isOpen && (
+              <dl className="mt-1.5 pl-1">
+                {items.map((c, i) => (
+                  <div key={i} className="mb-2">
+                    <dt className="text-xs font-mono font-medium text-foreground">
+                      {c.standard}
+                      {c.clause ? ` ${c.clause}` : ''}
+                    </dt>
+                    <dd className="text-xs text-muted-foreground leading-relaxed">{c.note}</dd>
+                  </div>
+                ))}
+              </dl>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/PolicyField.tsx
+++ b/src/components/PolicyField.tsx
@@ -1,0 +1,24 @@
+import type { NumericRecommendation } from '@/engine/types'
+import { formatMinutes } from '@/lib/formatMinutes'
+import { UpgradeNote } from './UpgradeNote'
+
+interface PolicyFieldProps {
+  label: string
+  field: NumericRecommendation
+}
+
+export function PolicyField({ label, field }: PolicyFieldProps) {
+  return (
+    <div className="flex flex-col">
+      <span className="text-[11px] font-medium uppercase tracking-label text-muted-foreground">
+        {label}
+      </span>
+      <span className="text-2xl font-semibold tracking-display text-foreground mt-0.5">
+        {formatMinutes(field.value)}
+      </span>
+      <p className="text-sm text-muted-foreground mt-0.5">{field.rationale}</p>
+      <p className="text-xs text-muted-foreground/70 mt-1 font-mono">{field.standardsFloor}</p>
+      <UpgradeNote note={field.upgradeNote} />
+    </div>
+  )
+}

--- a/src/components/PolicyWarningBanner.tsx
+++ b/src/components/PolicyWarningBanner.tsx
@@ -1,0 +1,44 @@
+import { AlertTriangle } from 'lucide-react'
+import type { PolicyWarning } from '@/engine/types'
+
+interface PolicyWarningBannerProps {
+  warnings: PolicyWarning[]
+}
+
+export function PolicyWarningBanner({ warnings }: PolicyWarningBannerProps) {
+  const conditional = warnings.filter((w) => w.kind === 'conditional')
+  const advisory = warnings.filter((w) => w.kind === 'advisory')
+
+  if (conditional.length === 0 && advisory.length === 0) return null
+
+  return (
+    <div className="flex flex-col gap-3">
+      {conditional.length > 0 && (
+        <div className="rounded-lg border border-warning-border bg-warning p-4">
+          <div className="flex gap-3 items-start">
+            <AlertTriangle size={16} className="text-warning-text shrink-0 mt-0.5" />
+            <div className="flex flex-col gap-2">
+              {conditional.map((w) => (
+                <p key={w.id} className="text-sm text-warning-text leading-relaxed">
+                  {w.message}
+                </p>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+      {advisory.length > 0 && (
+        <div className="flex flex-col gap-1.5 px-1">
+          {advisory.map((w) => (
+            <p key={w.id} className="text-xs text-muted-foreground leading-relaxed">
+              <span className="font-medium text-muted-foreground/80 uppercase tracking-label text-[10px] mr-1.5">
+                General advisory
+              </span>
+              {w.message}
+            </p>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/ReAuthTriggers.tsx
+++ b/src/components/ReAuthTriggers.tsx
@@ -1,0 +1,32 @@
+interface ReAuthTriggersProps {
+  idp: string[]
+  app: string[]
+}
+
+function TriggerList({ label, items }: { label: string; items: string[] }) {
+  if (items.length === 0) return null
+  return (
+    <div>
+      <p className="text-[11px] font-medium uppercase tracking-label text-muted-foreground mb-1">
+        {label}
+      </p>
+      <ul className="flex flex-col gap-0.5">
+        {items.map((trigger, i) => (
+          <li key={i} className="text-sm text-foreground leading-relaxed flex gap-2">
+            <span>·</span>
+            <span>{trigger}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export function ReAuthTriggers({ idp, app }: ReAuthTriggersProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      <TriggerList label="IdP session policy" items={idp} />
+      <TriggerList label="Application layer" items={app} />
+    </div>
+  )
+}

--- a/src/components/ResultCard.tsx
+++ b/src/components/ResultCard.tsx
@@ -1,0 +1,179 @@
+import { useState } from 'react'
+import { Copy, Check, Download, RotateCcw } from 'lucide-react'
+import type { PolicyResult, PolicyInputs } from '@/engine/types'
+import { Button } from '@/components/ui/button'
+import { PolicyWarningBanner } from './PolicyWarningBanner'
+import { PolicyField } from './PolicyField'
+import { RotationBadge } from './RotationBadge'
+import { TokenStorageField } from './TokenStorageField'
+import { ReAuthTriggers } from './ReAuthTriggers'
+import { CitationsPanel } from './CitationsPanel'
+import { UpgradeNote } from './UpgradeNote'
+import { toPolicyStatement } from '@/lib/toPolicyStatement'
+
+const FEDRAMP_VERSION_NOTE =
+  'Recommendations cite NIST SP 800-63B Rev 4 (August 2025). If your ATO references Rev 3, verify — AAL2 idle timeout was 30 minutes (SHALL) under Rev 3, relaxed to 1 hour (SHOULD) in Rev 4.'
+
+interface ResultCardProps {
+  result: PolicyResult
+  inputs: PolicyInputs
+  onReset: () => void
+}
+
+export function ResultCard({ result, inputs, onReset }: ResultCardProps) {
+  const [copied, setCopied] = useState(false)
+  const isM2M = inputs.appType === 'm2m'
+  const isFedRAMP =
+    inputs.complianceFramework === 'fedramp-moderate' ||
+    inputs.complianceFramework === 'fedramp-high'
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(toPolicyStatement(result, inputs))
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  const handleExportJSON = () => {
+    const blob = new Blob([JSON.stringify(result, null, 2)], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'token-policy.json'
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const showReAuth =
+    !isM2M &&
+    (result.reAuthTriggersIdp.length > 0 || result.reAuthTriggersApp.length > 0)
+
+  return (
+    <div className="rounded-xl border border-border bg-card shadow-sm">
+      {/* Header */}
+      <div className="flex items-center justify-between gap-4 border-b border-border px-6 py-4 sm:px-8">
+        <h2 className="text-base font-semibold tracking-display text-foreground">
+          Policy recommendation
+        </h2>
+        <div className="flex items-center gap-2 shrink-0">
+          <Button variant="default" size="sm" onClick={handleCopy} className="gap-1.5">
+            {copied ? <Check size={13} /> : <Copy size={13} />}
+            {copied ? 'Copied' : 'Copy policy'}
+          </Button>
+          <Button variant="outline" size="sm" onClick={handleExportJSON} className="gap-1.5">
+            <Download size={13} />
+            Export JSON
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-6 px-6 py-6 sm:px-8">
+        {/* Warnings */}
+        {result.warnings.length > 0 && (
+          <PolicyWarningBanner warnings={result.warnings} />
+        )}
+
+        {/* Recommended policy */}
+        <section>
+          <h3 className="text-[11px] font-medium uppercase tracking-label text-muted-foreground mb-4">
+            Recommended policy
+          </h3>
+
+          <div className="md:grid md:grid-cols-2 md:gap-x-8 gap-y-6 flex flex-col">
+            {/* Access token — always shown */}
+            <PolicyField label="Access token lifetime" field={result.accessTokenLifetime} />
+
+            {/* Refresh token lifetime — hidden for M2M or when null */}
+            {!isM2M && result.refreshTokenLifetime !== null && (
+              <PolicyField
+                label="Refresh token lifetime"
+                field={result.refreshTokenLifetime}
+              />
+            )}
+
+            {/* Rotation — hidden for M2M or when refresh tokens not in use */}
+            {!isM2M && result.refreshTokenRotation.value !== 'not-applicable' && (
+              <div className="md:col-span-2">
+                <RotationBadge rotation={result.refreshTokenRotation} />
+              </div>
+            )}
+          </div>
+
+          {!isM2M && (
+            <>
+              <div className="border-t border-border my-6" />
+
+              <div className="md:grid md:grid-cols-2 md:gap-x-8 gap-y-6 flex flex-col">
+                {result.absoluteSessionLimit !== null && (
+                  <PolicyField
+                    label="Absolute session limit"
+                    field={result.absoluteSessionLimit}
+                  />
+                )}
+                {result.idleTimeoutIdp !== null && (
+                  <PolicyField
+                    label="Idle timeout — IdP"
+                    field={result.idleTimeoutIdp}
+                  />
+                )}
+                {result.idleTimeoutApp !== null && (
+                  <PolicyField
+                    label="Idle timeout — application"
+                    field={result.idleTimeoutApp}
+                  />
+                )}
+              </div>
+
+              {isFedRAMP && (
+                <UpgradeNote note={FEDRAMP_VERSION_NOTE} />
+              )}
+            </>
+          )}
+
+          <div className="border-t border-border my-6" />
+
+          <TokenStorageField storage={result.tokenStorage} />
+        </section>
+
+        {/* Re-auth triggers */}
+        {showReAuth && (
+          <section>
+            <h3 className="text-[11px] font-medium uppercase tracking-label text-muted-foreground mb-4">
+              Re-authentication triggers
+            </h3>
+            <ReAuthTriggers
+              idp={result.reAuthTriggersIdp}
+              app={result.reAuthTriggersApp}
+            />
+          </section>
+        )}
+
+        {/* Citations */}
+        {result.citations.length > 0 && (
+          <section>
+            <h3 className="text-[11px] font-medium uppercase tracking-label text-muted-foreground mb-2">
+              Standards references
+            </h3>
+            <CitationsPanel citations={result.citations} />
+          </section>
+        )}
+
+        {/* Disclaimer */}
+        <div className="flex flex-col gap-2 pt-2 border-t border-border">
+          {result.disclaimer.map((p, i) => (
+            <p key={i} className="text-xs text-muted-foreground/70 leading-relaxed">
+              {p}
+            </p>
+          ))}
+        </div>
+
+        {/* Start over */}
+        <div className="flex justify-center pt-2">
+          <Button variant="ghost" size="sm" onClick={onReset} className="gap-1.5 text-muted-foreground">
+            <RotateCcw size={13} />
+            Start over
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ResultCard.tsx
+++ b/src/components/ResultCard.tsx
@@ -40,7 +40,7 @@ export function ResultCard({ result, inputs, onReset }: ResultCardProps) {
     a.href = url
     a.download = 'token-policy.json'
     a.click()
-    URL.revokeObjectURL(url)
+    setTimeout(() => URL.revokeObjectURL(url), 0)
   }
 
   const showReAuth =

--- a/src/components/RotationBadge.tsx
+++ b/src/components/RotationBadge.tsx
@@ -33,9 +33,11 @@ export function RotationBadge({ rotation }: RotationBadgeProps) {
       {!isNA && (
         <>
           <p className="text-sm text-muted-foreground mt-1">{rotation.rationale}</p>
-          <p className="text-xs text-muted-foreground/70 mt-1 font-mono">
-            {rotation.standardsFloor}
-          </p>
+          {rotation.value !== 'required' && rotation.standardsFloor && (
+            <p className="text-xs text-muted-foreground/70 mt-1 font-mono">
+              {rotation.standardsFloor}
+            </p>
+          )}
         </>
       )}
     </div>

--- a/src/components/RotationBadge.tsx
+++ b/src/components/RotationBadge.tsx
@@ -1,0 +1,43 @@
+import type { PolicyResult } from '@/engine/types'
+
+interface RotationBadgeProps {
+  rotation: PolicyResult['refreshTokenRotation']
+}
+
+const badgeClasses: Record<string, string> = {
+  required: 'bg-primary text-primary-foreground',
+  recommended: 'bg-accent text-accent-foreground',
+  'not-applicable': 'bg-muted text-muted-foreground',
+}
+
+const badgeLabel: Record<string, string> = {
+  required: 'Required',
+  recommended: 'Recommended',
+  'not-applicable': 'Not applicable',
+}
+
+export function RotationBadge({ rotation }: RotationBadgeProps) {
+  const isNA = rotation.value === 'not-applicable'
+  return (
+    <div className="flex flex-col">
+      <span className="text-[11px] font-medium uppercase tracking-label text-muted-foreground">
+        Refresh token rotation
+      </span>
+      <div className="mt-1">
+        <span
+          className={`inline-block rounded-pill px-2 py-0.5 text-xs font-medium ${badgeClasses[rotation.value]}`}
+        >
+          {badgeLabel[rotation.value]}
+        </span>
+      </div>
+      {!isNA && (
+        <>
+          <p className="text-sm text-muted-foreground mt-1">{rotation.rationale}</p>
+          <p className="text-xs text-muted-foreground/70 mt-1 font-mono">
+            {rotation.standardsFloor}
+          </p>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/components/TokenStorageField.tsx
+++ b/src/components/TokenStorageField.tsx
@@ -1,0 +1,19 @@
+import type { PolicyResult } from '@/engine/types'
+import { UpgradeNote } from './UpgradeNote'
+
+interface TokenStorageFieldProps {
+  storage: PolicyResult['tokenStorage']
+}
+
+export function TokenStorageField({ storage }: TokenStorageFieldProps) {
+  return (
+    <div className="flex flex-col">
+      <span className="text-[11px] font-medium uppercase tracking-label text-muted-foreground">
+        Token storage
+      </span>
+      <p className="text-base font-semibold text-foreground mt-0.5">{storage.recommendation}</p>
+      <p className="text-sm text-muted-foreground mt-0.5">{storage.rationale}</p>
+      <UpgradeNote note={storage.upgradeNote} />
+    </div>
+  )
+}

--- a/src/components/UpgradeNote.tsx
+++ b/src/components/UpgradeNote.tsx
@@ -1,0 +1,15 @@
+import { Lightbulb } from 'lucide-react'
+
+interface UpgradeNoteProps {
+  note: string | undefined
+}
+
+export function UpgradeNote({ note }: UpgradeNoteProps) {
+  if (!note) return null
+  return (
+    <div className="rounded-md border border-upgrade-border bg-upgrade p-2.5 mt-2 flex gap-2 items-start">
+      <Lightbulb size={12} className="text-upgrade-text shrink-0 mt-0.5" />
+      <p className="text-xs text-upgrade-text leading-relaxed">{note}</p>
+    </div>
+  )
+}

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -572,7 +572,7 @@ export function computePolicy(inputs: PolicyInputs): PolicyResult {
     refreshTokenRotation = {
       value: bindingRationale ? 'recommended' : 'required',
       rationale:
-        bindingRationale ?? 'No sender-constraining configured — rotation satisfies the public client requirement.',
+        bindingRationale ?? 'Rotation required for public clients (RFC 9700 §2.2.2).',
       standardsFloor:
         'RFC 9700 §2.2.2: refresh tokens for public clients MUST be sender-constrained or use rotation.',
     }

--- a/src/hooks/useStepFlow.ts
+++ b/src/hooks/useStepFlow.ts
@@ -87,6 +87,12 @@ export function useStepFlow() {
 
   const canGoBack = findNextUnskipped(currentStepIndex, -1, inputs) !== null
 
+  const reset = useCallback(() => {
+    setInputs({})
+    setCurrentStepIndex(0)
+    setDirection(1)
+  }, [])
+
   return {
     currentStepIndex,
     inputs,
@@ -98,6 +104,7 @@ export function useStepFlow() {
     goToStep,
     isComplete,
     canGoBack,
+    reset,
     totalSteps: STEP_CONFIGS.length,
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -35,6 +35,10 @@
     --warning-bg: 48 96% 89%;        /* amber */
     --warning-text: 28 73% 26%;
     --warning-border: 48 96% 77%;
+
+    --upgrade-bg: 12 100% 95%;
+    --upgrade-text: 12 60% 30%;
+    --upgrade-border: 12 80% 82%;
   }
 
   .dark {
@@ -61,6 +65,10 @@
     --warning-bg: 28 50% 12%;
     --warning-text: 48 80% 70%;
     --warning-border: 28 40% 25%;
+
+    --upgrade-bg: 12 40% 12%;
+    --upgrade-text: 12 80% 70%;
+    --upgrade-border: 12 40% 22%;
   }
 
   * {

--- a/src/lib/formatMinutes.ts
+++ b/src/lib/formatMinutes.ts
@@ -1,0 +1,9 @@
+export function formatMinutes(n: number): string {
+  if (n < 60) return `${n} min`
+  if (n < 1440) {
+    const h = n / 60
+    return h === 1 ? '1 hour' : `${h} hours`
+  }
+  const d = n / 1440
+  return d === 1 ? '1 day' : `${d} days`
+}

--- a/src/lib/toPolicyStatement.ts
+++ b/src/lib/toPolicyStatement.ts
@@ -27,10 +27,20 @@ export function toPolicyStatement(result: PolicyResult, inputs: PolicyInputs): s
     )
   }
 
-  if (result.idleTimeoutIdp !== null) {
-    sentences.push(
-      `Idle timeout: ${formatMinutes(result.idleTimeoutIdp.value)} (IdP and application).`
-    )
+  if (result.idleTimeoutIdp !== null && result.idleTimeoutApp !== null) {
+    if (result.idleTimeoutIdp.value === result.idleTimeoutApp.value) {
+      sentences.push(
+        `Idle timeout: ${formatMinutes(result.idleTimeoutIdp.value)} (IdP and application).`
+      )
+    } else {
+      sentences.push(
+        `Idle timeout: ${formatMinutes(result.idleTimeoutIdp.value)} (IdP), ${formatMinutes(result.idleTimeoutApp.value)} (application).`
+      )
+    }
+  } else if (result.idleTimeoutIdp !== null) {
+    sentences.push(`Idle timeout — IdP: ${formatMinutes(result.idleTimeoutIdp.value)}.`)
+  } else if (result.idleTimeoutApp !== null) {
+    sentences.push(`Idle timeout — application: ${formatMinutes(result.idleTimeoutApp.value)}.`)
   }
 
   sentences.push(`Token storage: ${result.tokenStorage.recommendation}.`)

--- a/src/lib/toPolicyStatement.ts
+++ b/src/lib/toPolicyStatement.ts
@@ -1,0 +1,51 @@
+import type { PolicyResult, PolicyInputs } from '@/engine/types'
+import { formatMinutes } from './formatMinutes'
+
+export function toPolicyStatement(result: PolicyResult, inputs: PolicyInputs): string {
+  const sentences: string[] = []
+
+  sentences.push(
+    `Access token lifetime: ${formatMinutes(result.accessTokenLifetime.value)}.`
+  )
+
+  if (result.refreshTokenLifetime !== null) {
+    const rotation = result.refreshTokenRotation.value
+    const rotationNote =
+      rotation === 'required'
+        ? ', with rotation required'
+        : rotation === 'recommended'
+        ? ', with rotation recommended'
+        : ''
+    sentences.push(
+      `Refresh token lifetime: ${formatMinutes(result.refreshTokenLifetime.value)}${rotationNote}.`
+    )
+  }
+
+  if (result.absoluteSessionLimit !== null) {
+    sentences.push(
+      `Absolute session limit: ${formatMinutes(result.absoluteSessionLimit.value)}.`
+    )
+  }
+
+  if (result.idleTimeoutIdp !== null) {
+    sentences.push(
+      `Idle timeout: ${formatMinutes(result.idleTimeoutIdp.value)} (IdP and application).`
+    )
+  }
+
+  sentences.push(`Token storage: ${result.tokenStorage.recommendation}.`)
+
+  const appType = inputs.appType ?? 'server'
+  const appLabel: Record<string, string> = {
+    spa: 'single-page application',
+    server: 'server-side application',
+    mobile: 'mobile application',
+    m2m: 'machine-to-machine client',
+  }
+
+  sentences.push(
+    `This policy applies to a ${appLabel[appType]}. Recommendations are grounded in NIST SP 800-63B Rev 4, RFC 9700, RFC 6749, RFC 9068, and draft-ietf-oauth-browser-based-apps-26. This is not a compliance determination — verify against your ATO, organizational requirements, or legal counsel.`
+  )
+
+  return sentences.join(' ')
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -46,6 +46,11 @@ export default {
           text: 'hsl(var(--warning-text))',
           border: 'hsl(var(--warning-border))',
         },
+        upgrade: {
+          DEFAULT: 'hsl(var(--upgrade-bg))',
+          text: 'hsl(var(--upgrade-text))',
+          border: 'hsl(var(--upgrade-border))',
+        },
       },
       fontFamily: {
         sans: ['"IBM Plex Sans"', 'sans-serif'],


### PR DESCRIPTION
Closes #13

## What's in this PR

Replaces the Phase 5 placeholder with a fully functional result card.

**New components**
- `ResultCard` — orchestrates the full output screen
- `PolicyField` — numeric field with value, rationale, and standards floor
- `RotationBadge` — refresh token rotation pill with contextual copy
- `TokenStorageField` — storage recommendation with upgrade note
- `PolicyWarningBanner` — conditional and advisory warnings
- `ReAuthTriggers` — IdP and application-layer re-auth trigger lists
- `CitationsPanel` — collapsible accordion grouped by field
- `UpgradeNote` — tip card for optional improvements

**New lib**
- `formatMinutes` — formats minutes to human-readable string (30 min, 1 hour, 1 day)
- `toPolicyStatement` — plain-text policy summary for clipboard copy

**Other**
- `reset()` added to `useStepFlow`
- `upgrade` color tokens added (light + dark)
- Export JSON downloads `token-policy.json`
- Rotation copy simplified: "Rotation required for public clients (RFC 9700 §2.2.2)."
- `computePolicy` memoized in App; safe `PolicyInputs` cast; blob URL revoke deferred; idle timeout copy handles divergent IdP/app values

## Verified scenarios
Full flow · M2M path · Refresh=No · FedRAMP note · Citations toggle · Copy · Export JSON · Start over · SPA+FedRAMP High warnings · No nulls in JSON output

## Issues filed for Phase 7
- #15 Remove idle session behavior question (input has no effect on numeric output)
- #16 Header copy — rename to Token Policy, fix subtitle
- #17 Input summary strip on result card
- #18 Warning block discrete treatment
- #19 Two-tier visual separation
- #20 Grid layout — pair idle timeout fields
- #21 Result card length — citations consolidation